### PR TITLE
Removing startup logging message from RQ

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -464,7 +464,7 @@ class Worker(object):
         self.set_state(WorkerStatus.STARTED)
         qnames = self.queue_names()
         self.log.info('*** Listening on %s...', green(', '.join(qnames)))
-        LoggingUtils.info("*** Listening on {}...".format(', '.join(qnames)), color=LoggingUtils.LGREEN)
+        # LoggingUtils.info("*** Listening on {}...".format(', '.join(qnames)), color=LoggingUtils.LGREEN)
 
         try:
             while True:


### PR DESCRIPTION
Remove this logging message because Izumi will constantly expect a timeout - this will flood logs otherwise.